### PR TITLE
Add PyYAML to installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "asyncio",
         "beautifulsoup4",
         "playwright",
+        "PyYAML",
         "tldextract",
         "urllib3",
     ],
@@ -78,3 +79,4 @@ else:
         + target_directory
         + "/config.yml has been created.\n\033[0m"
     )
+


### PR DESCRIPTION
Added PyYAML to the list of install requirements to avoid runtime issues..

````bash
$ ./result/bin/xnldorker 
Traceback (most recent call last):
  File "/nix/store/ws0hvyl73snkzrbwf4nm95gmy406h3mh-xnldorker-4.1/bin/.xnldorker-wrapped", line 6, in <module>
    from xnldorker.xnldorker import main
  File "/nix/store/ws0hvyl73snkzrbwf4nm95gmy406h3mh-xnldorker-4.1/lib/python3.13/site-packages/xnldorker/xnldorker.py", line 29, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
````